### PR TITLE
Refactor: Redirect root to login page

### DIFF
--- a/src/app/page.js
+++ b/src/app/page.js
@@ -1,25 +1,7 @@
 "use client";
 
-import { useEffect } from 'react';
-import { useRouter } from 'next/navigation';
-import Cookies from 'js-cookie'; // Import Cookies
+import LoginPage from './login/page';
 
 export default function HomePage() {
-  const router = useRouter();
-
-  useEffect(() => {
-    const token = Cookies.get('firebase_id_token');
-    if (token) {
-      router.replace('/dashboard'); // Redirect to dashboard if authenticated
-    } else {
-      router.replace('/login'); // Redirect to login if not authenticated
-    }
-  }, [router]);
-
-  // Optionally, render a loading spinner or message while redirecting
-  return (
-    <div className="flex items-center justify-center min-h-screen bg-gray-100">
-      <p className="text-gray-700">Redirecting...</p>
-    </div>
-  );
+  return <LoginPage />;
 }


### PR DESCRIPTION
Remove redundant redirection logic from the root page and directly render the `LoginPage` component. This simplifies the initial routing flow and centralizes login handling.